### PR TITLE
Add served storybook support

### DIFF
--- a/src/api/ensureOptionsDefaults.js
+++ b/src/api/ensureOptionsDefaults.js
@@ -9,6 +9,7 @@ function ensureOptionsDefaults(options) {
     storyNameRegex,
     storyKindRegex,
     out = "storybook",
+    host,
     pa11yOptions = {},
     test: testMethod = pa11y
   } = options;
@@ -28,6 +29,7 @@ function ensureOptionsDefaults(options) {
     storyNameRegex,
     storyKindRegex,
     out,
+    host,
     pa11yOptions: {
       chromeLaunchConfig: {
         args: ["--no-sandbox", ...chromeLaunchConfigArgs],

--- a/src/api/ensureOptionsDefaults.js
+++ b/src/api/ensureOptionsDefaults.js
@@ -9,7 +9,7 @@ function ensureOptionsDefaults(options) {
     storyNameRegex,
     storyKindRegex,
     out = "storybook",
-    host,
+    host = `file://${process.cwd()}/${options.out || "storybook"}`,
     pa11yOptions = {},
     test: testMethod = pa11y
   } = options;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -47,6 +47,7 @@ function testStoryPa11y(options = {}) {
     storyNameRegex,
     storyKindRegex,
     out,
+    host,
     pa11yOptions,
     testMethod
   } = ensureOptionsDefaults(options);
@@ -66,6 +67,7 @@ function testStoryPa11y(options = {}) {
     storyKindRegex,
     storyNameRegex,
     out,
+    host,
     pa11yOptions,
     testMethod,
     testMethodParams

--- a/src/api/pa11yTestsTemplate.js
+++ b/src/api/pa11yTestsTemplate.js
@@ -7,12 +7,13 @@ function pa11yTest({
   fileName,
   framework,
   out,
+  host,
   pa11yOptions,
   testMethod,
   testMethodParams,
 }) {
   const { name } = story;
-  const context = { fileName, kind, story: name, framework, out, pa11yOptions };
+  const context = { fileName, kind, story: name, framework, out, host, pa11yOptions };
 
   if (asyncJest === true) {
     it(name, done =>

--- a/src/test-bodies.js
+++ b/src/test-bodies.js
@@ -1,5 +1,11 @@
 export const pa11y = async ({ story, context }) => {
-  const url = `file://${process.cwd()}/${context.out}/iframe.html?selectedKind=${encodeURIComponent(
+  let host = `file://${process.cwd()}/${context.out}`;
+
+  if(context.host) {
+    host = context.host.replace(/\/$/, '');
+  }
+
+  const url = `${host}/iframe.html?selectedKind=${encodeURIComponent(
     context.kind,
   )}&selectedStory=${encodeURIComponent(context.story)}`;
 

--- a/src/test-bodies.js
+++ b/src/test-bodies.js
@@ -1,11 +1,5 @@
 export const pa11y = async ({ story, context }) => {
-  let host = `file://${process.cwd()}/${context.out}`;
-
-  if(context.host) {
-    host = context.host.replace(/\/$/, '');
-  }
-
-  const url = `${host}/iframe.html?selectedKind=${encodeURIComponent(
+  const url = `${context.host}/iframe.html?selectedKind=${encodeURIComponent(
     context.kind,
   )}&selectedStory=${encodeURIComponent(context.story)}`;
 


### PR DESCRIPTION
This change allows you to set a `host` in the storypa11y config. You can set a local webserver (e.g. `http://localhost:6006`) as a testing environment instead of a static storybook app (e.g. `file://...`). This makes integration with other storybook addons such as [storyshots-puppeteer](https://github.com/storybookjs/storybook/tree/next/addons/storyshots/storyshots-puppeteer) and jest possible which open their own webserver for testing. Instead of then testing a11y separately on a static storybook app you can use this existing server for your storypa11y tests too.